### PR TITLE
Fix: correct fastapi() to FastAPI() in line 3

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from fastapi import *
 from fastapi.responses import FileResponse
-app=fastapi()
+app=FastAPI()
 
 # Static Pages (Never Modify Code in this Block)
 @app.get("/", include_in_schema=False)


### PR DESCRIPTION
WeHelp Guide - Part 0 - 丁綾葳